### PR TITLE
fix exec breakpoint when using search bar without categoryButtons

### DIFF
--- a/Wakup/SearchViewController.swift
+++ b/Wakup/SearchViewController.swift
@@ -24,7 +24,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, UITableViewDa
     @IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet weak var tableView: UITableView!
     
-    @IBOutlet weak var filterButtonsScrollView: UIScrollView!
+    @IBOutlet var filterButtonsScrollView: UIScrollView!
     
     var categoryButtons: [SearchFilterButton]?
     var categoryButtonNib = UINib(nibName: "SearchFilterButton", bundle: Bundle(for: SearchViewController.self))


### PR DESCRIPTION
When there was no _categoryButtons_ this code in line 56 `tableView.tableHeaderView = nil` makes `@IBOutlet weak var filterButtonsScrollView: UIScrollView!` to become **nil**, producing a breakpoint. 